### PR TITLE
Remove unnecessary dependencies and unwanted files during remote install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ README.md
 # ignore files prefaced with OLD_
 OLD_*
 
-
+# ignore .git directory
+.git

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Relatively few dependencies. These are needed regardless of whether installing l
 - Apache v 2.4
 - Ruby v 3.x
 - sqlite3
-- These Ruby gems: sanitize, sqlite3, sequel, date
+- These Ruby gems: sanitize, sqlite3, sequel
 
 Is that really it? Yes. That is all you need. 
 

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,10 @@ rm forms/.gitignore
 rm assets/images/.gitignore
 rm assets/styles/.gitignore
 
+# remove .git and .gitigore
+rm -R .git
+rm .gitignore
+
 # move files out of the zurfbirb folder, first backing up the old .htaccess
 mv ../.htaccess ../OLD_htaccess
 mv -ft .. ./*

--- a/install.sh
+++ b/install.sh
@@ -55,8 +55,8 @@ rm assets/images/.gitignore
 rm assets/styles/.gitignore
 
 # remove .git and .gitigore
-rm -R .git
-rm .gitignore
+rm -Rf .git
+rm -f .gitignore
 
 # move files out of the zurfbirb folder, first backing up the old .htaccess
 mv ../.htaccess ../OLD_htaccess

--- a/sudo-gems.sh
+++ b/sudo-gems.sh
@@ -4,9 +4,7 @@ echo "On most Linux systems it will ask you for your password (not root's) to ru
 sudo apt-get install build-essential
 sudo apt-get install pkgconf
 sudo apt-get install sqlite3
-sudo apt-get install libsqlite3-dev
 # install gems
 sudo gem install sanitize
 sudo gem install sqlite3
 sudo gem install sequel
-sudo gem install date


### PR DESCRIPTION
Remove the unnecessary dependency on the external Ruby gem `'date'` and its dependencies in gem installation script - the built-in ruby DateTime class is sufficient for our needs. Also have the install script remove additional unwanted files (`.git` folder and the `.gitignore` file in repository root) that may be brought over from the repository.